### PR TITLE
Revert "RHBA-662 - Fix group ID. (#3)"

### DIFF
--- a/jboss-javaee-7.0-with-rhpam/README.md
+++ b/jboss-javaee-7.0-with-rhpam/README.md
@@ -11,7 +11,7 @@ To use the BOM, import into your dependency management:
     <dependencyManagement>
         <dependencies>
             <dependency>
-               <groupId>org.jboss.bom.rhpam</groupId>
+               <groupId>org.jboss.bom.rhba</groupId>
                <artifactId>jboss-javaee-7.0-with-rhpam</artifactId>
                <version>7.0.0-SNAPSHOT</version>
                <type>pom</scope>

--- a/jboss-javaee-7.0-with-rhpam/pom.xml
+++ b/jboss-javaee-7.0-with-rhpam/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.jboss.bom.rhpam</groupId>
+        <groupId>org.jboss.bom.rhba</groupId>
         <artifactId>rhpam-bom-parent</artifactId>
         <version>7.0.0-SNAPSHOT</version>
     </parent>
@@ -33,7 +33,7 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>org.jboss.bom.rhpam</groupId>
+                <groupId>org.jboss.bom.rhba</groupId>
                 <artifactId>rhpam-bom</artifactId>
                 <version>${project.version}</version>
                 <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.jboss.bom.rhpam</groupId>
+    <groupId>org.jboss.bom.rhba</groupId>
     <artifactId>rhpam-bom-parent</artifactId>
     <version>7.0.0-SNAPSHOT</version>
 

--- a/rhpam-bom/README.md
+++ b/rhpam-bom/README.md
@@ -11,7 +11,7 @@ To use the BOM, import into your dependency management:
     <dependencyManagement>
         <dependencies>
             <dependency>
-               <groupId>org.jboss.bom.rhpam</groupId>
+               <groupId>org.jboss.bom.rhba</groupId>
                <artifactId>rhpam-bom</artifactId>
                <version>7.0.0-SNAPSHOT</version>
                <type>pom</scope>

--- a/rhpam-bom/pom.xml
+++ b/rhpam-bom/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.jboss.bom.rhpam</groupId>
+        <groupId>org.jboss.bom.rhba</groupId>
         <artifactId>rhpam-bom-parent</artifactId>
         <version>7.0.0-SNAPSHOT</version>
     </parent>

--- a/rhpam-platform-bom/README.md
+++ b/rhpam-platform-bom/README.md
@@ -13,7 +13,7 @@ To use the BOM, import into your dependency management:
     <dependencyManagement>
         <dependencies>
             <dependency>
-               <groupId>org.jboss.bom.rhpam</groupId>
+               <groupId>org.jboss.bom.rhba</groupId>
                <artifactId>rhpam-platform-bom</artifactId>
                <version>7.0.0-SNAPSHOT</version>
                <type>pom</scope>

--- a/rhpam-platform-bom/pom.xml
+++ b/rhpam-platform-bom/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.jboss.bom.rhpam</groupId>
+        <groupId>org.jboss.bom.rhba</groupId>
         <artifactId>rhpam-bom-parent</artifactId>
         <version>7.0.0-SNAPSHOT</version>
     </parent>


### PR DESCRIPTION
This reverts commit fb4d6a05d45fafdd8a35f435f99a284b92c58703.

As we discussed,  let's keep the rhba as groupid identify for the moment.